### PR TITLE
Fix problem sample project can not build with Xcode 9.3.1

### DIFF
--- a/Example/Luminous.xcodeproj/project.pbxproj
+++ b/Example/Luminous.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1633C01520B317CF00587D02 /* ExternalAccessory.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1633C01420B317CF00587D02 /* ExternalAccessory.framework */; };
 		39FF278F42A0DEBC776FB2DC /* Pods_Luminous_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AFD7C3DE1862D85F123FCFE /* Pods_Luminous_Tests.framework */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
@@ -31,6 +32,7 @@
 /* Begin PBXFileReference section */
 		0B9A3C597A4625F955149A10 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		12C9ED1B8407D35B56FB3FE1 /* Pods-Luminous_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Luminous_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Luminous_Example/Pods-Luminous_Example.release.xcconfig"; sourceTree = "<group>"; };
+		1633C01420B317CF00587D02 /* ExternalAccessory.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ExternalAccessory.framework; path = System/Library/Frameworks/ExternalAccessory.framework; sourceTree = SDKROOT; };
 		29865AF20A1F6392CE7B968C /* Pods-Luminous_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Luminous_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Luminous_Example/Pods-Luminous_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		3AFD7C3DE1862D85F123FCFE /* Pods_Luminous_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Luminous_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		43AA1BFB0016BBB63F8256F2 /* Pods_Luminous_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Luminous_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -56,6 +58,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1633C01520B317CF00587D02 /* ExternalAccessory.framework in Frameworks */,
 				65B5AFB931022ED9C000CBC3 /* Pods_Luminous_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -156,6 +159,7 @@
 		BC0030B6C309788B1D6B6E31 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				1633C01420B317CF00587D02 /* ExternalAccessory.framework */,
 				43AA1BFB0016BBB63F8256F2 /* Pods_Luminous_Example.framework */,
 				3AFD7C3DE1862D85F123FCFE /* Pods_Luminous_Tests.framework */,
 			);


### PR DESCRIPTION
Hi, thank you for your great project.
I tried to build sample project included this repository, but unfortunately Xcode raise linker error and could not build. Here is error message.

```
Undefined symbols for architecture x86_64:
  "_OBJC_CLASS_$_EAAccessory", referenced from:
      objc-class-ref in ViewController.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

# Solution
Add ExternalAccessory.framework in Xcode `Luminous_Example -> Build Phases -> Link BInary With Libraries`.
It worked fine in my machine. (macOS 10.13.4 and Xcode 9.3.1)

