### PR TITLE
Fix for playback pausing when getting volume

### DIFF
--- a/Sources/Luminous/Luminous+Audio.swift
+++ b/Sources/Luminous/Luminous+Audio.swift
@@ -22,7 +22,6 @@ extension Luminous {
             do {
                 try audioSession.setActive(true)
                 let volume = audioSession.outputVolume
-                try audioSession.setActive(false)
                 return Double(volume)
             } catch {
                 print("Luminous - Failed to activate audio session.")


### PR DESCRIPTION
There is an issue with the current implementation of Audio's `currentAudioOutputVolume`: when called, any playback that is going on (AVPlayer, ...) will pause. By applying this change, playbacks will continue as expected.

Please note that I don't know the impact of not setting active to false. As far as I can tell there is no problem, and it's likely even less a problem when the app actually is using or going to use audio.